### PR TITLE
fixed port mapping issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   openwebui:
     image: tmfrisinger/open-webui:1.0.1
     ports:
-      - "3000:8080"
+      - "3000:3000"
     environment:
       - HOST=0.0.0.0
       - PORT=3000


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Docker Compose configuration to map the openwebui service to port 3000 on both the host and container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->